### PR TITLE
VulkanCore meant for

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Wrapper around [SPIR-V Cross](https://github.com/KhronosGroup/SPIRV-Cross) gener
 
 This package intends to provide Julia bindings to the C API of SPIR-V Cross, and will suit the needs of those who only want a barebone wrapper. Abstractions, however, are not planned at the moment, though the package contains a few convenience functions to reflect into compiled SPIR-V shaders.
 
-It is currently used in conjunction with [VulkanCore.jl](https://github.com/JuliaGPU/VulkanCore.jl) (under active development).
+It is currently used in conjunction with [VulkanCore.jl](https://github.com/JuliaGPU/VulkanCore.jl). See also a (fork of the) higher-layer [Vulkan.jl](https://github.com/serenity4/Vulkan.jl) (under active development).

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Wrapper around [SPIR-V Cross](https://github.com/KhronosGroup/SPIRV-Cross) gener
 
 This package intends to provide Julia bindings to the C API of SPIR-V Cross, and will suit the needs of those who only want a barebone wrapper. Abstractions, however, are not planned at the moment, though the package contains a few convenience functions to reflect into compiled SPIR-V shaders.
 
-It is currently used in conjunction with [Vulkan.jl](https://github.com/JuliaGPU/Vulkan.jl) (under active development).
+It is currently used in conjunction with [VulkanCore.jl](https://github.com/JuliaGPU/VulkanCore.jl) (under active development).


### PR DESCRIPTION
VulkanCore.jl I see is under development, and the higher-level interface not for 5 years! So I'm just guessing here, asking, is this a correct PR? Even if Vulkan.jl is under development is it better to link (for now at least) elsewhere?